### PR TITLE
fix: Use updated kwargs of new_site

### DIFF
--- a/build/frappe-worker/commands/new.py
+++ b/build/frappe-worker/commands/new.py
@@ -57,8 +57,8 @@ def main():
         _new_site(
             None,
             site_name,
-            mariadb_root_username=db_root_username,
-            mariadb_root_password=db_root_password,
+            db_root_username=db_root_username,
+            db_root_password=db_root_password,
             admin_password=get_password("ADMIN_PASSWORD", 'admin'),
             verbose=True,
             install_apps=install_apps,


### PR DESCRIPTION
Update arguments to use `db_root_username` and `db_root_password` instead of `mariadb_root_username` and `mariadb_root_password` respectively.